### PR TITLE
feat: add --no-resolve-usernames flag to skip users.info API calls

### DIFF
--- a/slackexport/cli.py
+++ b/slackexport/cli.py
@@ -26,8 +26,10 @@ def main(argv=None) -> None:
                         help="Document title (default: 'Slack Thread')")
     parser.add_argument("--token",   default=os.environ.get("SLACK_BOT_TOKEN", ""),
                         help="Slack Bot Token (or set SLACK_BOT_TOKEN env var)")
-    parser.add_argument("--mock",    action="store_true",
+    parser.add_argument("--mock",   action="store_true",
                         help="Use mock data (no Slack token required, for testing)")
+    parser.add_argument("--no-resolve-usernames",   action="store_true",
+                        help="Skip resolving usernames and use raw user IDs")
     parser.add_argument("--version", "-V", action="version",
                         version=f"%(prog)s {__version__}")
 
@@ -64,6 +66,7 @@ def main(argv=None) -> None:
             output_path=output,
             fmt=args.format,
             title=args.title,
+            no_resolve_usernames=args.no_resolve_usernames
         )
         print(f"  Exported to {path}")
     except (ConnectionError, PermissionError, RuntimeError) as exc:

--- a/slackexport/exporter.py
+++ b/slackexport/exporter.py
@@ -181,6 +181,7 @@ def export_thread(
     output_path: str,
     fmt: str = "markdown",
     title: str = "Slack Thread",
+    no_resolve_usernames: bool = False,
 ) -> str:
     """Export a Slack thread to a file.
 
@@ -204,7 +205,7 @@ def export_thread(
     str
         The output file path.
     """
-    exporter  = ThreadExporter(client)
+    exporter  = ThreadExporter(client,resolve_usernames=not no_resolve_usernames)
     messages  = exporter.fetch(channel, thread_ts)
 
     if fmt == "html":


### PR DESCRIPTION
Adds a --no-resolve-usernames CLI flag to skip resolving Slack user IDs via users.info API.

## Changes
- Introduced --no-resolve-usernames flag in CLI
- Passed flag through to export_thread
- Reused existing resolve_usernames logic in ThreadExporter

##Behavior
- Default: resolves user IDs to display names (e.g., Alice)
- With flag: outputs raw user IDs (e.g., U123456)

## Why
Useful when Slack bot token does not have users:read scope or to avoid unnecessary API calls.

## Testing
Tested using --mock:
- Default → usernames shown  
- With flag → user IDs shown  

Closes #2