### PR TITLE
feat: add --since flag to filter messages by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/
 .DS_Store
 Thumbs.db
 exports/
+thread_*.md

--- a/slackexport/cli.py
+++ b/slackexport/cli.py
@@ -28,6 +28,8 @@ def main(argv=None) -> None:
                         help="Slack Bot Token (or set SLACK_BOT_TOKEN env var)")
     parser.add_argument("--mock",    action="store_true",
                         help="Use mock data (no Slack token required, for testing)")
+    parser.add_argument("--since",   type=str,   
+                        help="Filter messages after given date (YYYY-MM-DD)")
     parser.add_argument("--version", "-V", action="version",
                         version=f"%(prog)s {__version__}")
 
@@ -64,6 +66,7 @@ def main(argv=None) -> None:
             output_path=output,
             fmt=args.format,
             title=args.title,
+            since=args.since,
         )
         print(f"  Exported to {path}")
     except (ConnectionError, PermissionError, RuntimeError) as exc:

--- a/slackexport/exporter.py
+++ b/slackexport/exporter.py
@@ -181,6 +181,7 @@ def export_thread(
     output_path: str,
     fmt: str = "markdown",
     title: str = "Slack Thread",
+    since: Optional[str] = None,
 ) -> str:
     """Export a Slack thread to a file.
 
@@ -198,14 +199,28 @@ def export_thread(
         Output format: ``"markdown"`` or ``"html"``.
     title:
         Document title.
+    since:
+    Optional date (YYYY-MM-DD). Only messages after this date are included.
 
     Returns
     -------
     str
         The output file path.
     """
+    from datetime import datetime
+    
+    since_dt = None
+    if since:
+        since_dt = datetime.strptime(since, "%Y-%m-%d")
+
     exporter  = ThreadExporter(client)
     messages  = exporter.fetch(channel, thread_ts)
+
+    if since_dt:
+        messages = [
+            msg for msg in messages
+            if datetime.fromtimestamp(float(msg.ts.split('.')[0])) >= since_dt
+        ]
 
     if fmt == "html":
         content = exporter.to_html(messages, title=title)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -4,7 +4,7 @@ import pytest
 from slackexport.client import MockSlackClient, SlackMessage
 from slackexport.formatter import slack_to_markdown, ts_to_datetime
 from slackexport.exporter import ThreadExporter
-
+from datetime import datetime
 
 class TestFormatter:
     def test_bold(self):
@@ -100,3 +100,17 @@ class TestThreadExporter:
         msgs = exp.fetch(mock.MOCK_CHANNEL, mock.MOCK_THREAD_TS)
         md = exp.to_markdown(msgs)
         assert "# Slack Thread" in md
+    
+    def test_since_filters_messages(self):
+        mock = MockSlackClient()
+        exp = ThreadExporter(mock)
+        
+        msgs = exp.fetch(mock.MOCK_CHANNEL, mock.MOCK_THREAD_TS)
+        since_dt = datetime.strptime("2025-01-01", "%Y-%m-%d")
+
+        filtered = [
+            msg for msg in msgs
+            if datetime.fromtimestamp(float(msg.ts.split('.')[0])) >= since_dt
+        ]
+
+        assert len(filtered) == 0


### PR DESCRIPTION
Adds a --since CLI flag to filter exported Slack messages by date.

Changes

* Added --since argument to CLI
* Parsed input date using datetime.strptime
* Filtered messages in export_thread based on timestamp
* Reused existing message structures and utilities

Behavior

* Default: exports all messages
* With --since YYYY-MM-DD: exports only messages on or after the given date

Testing

* Added unit test to validate filtering behavior
* All existing and new tests pass

Closes #1